### PR TITLE
Don't display empty files, such as Mac OS X 'Icon' files.

### DIFF
--- a/lib/ferver/found_file.rb
+++ b/lib/ferver/found_file.rb
@@ -10,7 +10,7 @@ module Ferver
     end
 
     def valid?
-      File.file?(path_to_file)
+      File.file?(path_to_file) && File.size(path_to_file) > 0
     end
   end
 end


### PR DESCRIPTION
Title says it all.